### PR TITLE
Bump version to 0.0.156, ahead of published 0.0.155

### DIFF
--- a/src/sweetrpg_model_core/__init__.py
+++ b/src/sweetrpg_model_core/__init__.py
@@ -7,7 +7,7 @@ Root.
 __title__ = "SweetRPG Model Core"
 __description__ = "Base classes and utilities for model objects"
 __url__ = "https://github.com/sweetrpg/model-core"
-__version__ = "0.0.153"
+__version__ = "0.0.156"
 __build__ = 0x000063
 __author_email__ = "dm@sweetrpg.com"
 __license__ = "MIT"


### PR DESCRIPTION
PyMongo was already bumped to ~=4.0 on develop (fixing the Python 3.14 collections.MutableMapping ImportError this platform's floor requires), but never actually released - git tags here stop at 0.0.153 while PyPI already has 0.0.155 published, apparently from earlier CI runs whose tag-push step failed silently. Bumping past 0.0.155 so this release lands cleanly.

Verified locally under Python 3.14.6 with pymongo==4.17.0: all 18 tests pass.

This unblocks sweetrpg-client (and everything depending on sweetrpg-model-core/-api-core/-catalog-objects), which currently crashes on import under Python 3.14 via this exact transitive chain.