### PR TITLE
Use timezone-aware datetime instead of deprecated utcnow()

### DIFF
--- a/src/sweetrpg_model_core/__init__.py
+++ b/src/sweetrpg_model_core/__init__.py
@@ -7,7 +7,7 @@ Root.
 __title__ = "SweetRPG Model Core"
 __description__ = "Base classes and utilities for model objects"
 __url__ = "https://github.com/sweetrpg/model-core"
-__version__ = "0.0.156"
+__version__ = "0.0.157"
 __build__ = 0x000063
 __author_email__ = "dm@sweetrpg.com"
 __license__ = "MIT"

--- a/src/sweetrpg_model_core/model/base.py
+++ b/src/sweetrpg_model_core/model/base.py
@@ -6,7 +6,7 @@ Base objects for model and embedded model.
 
 from reprlib import recursive_repr
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from sweetrpg_model_core.convert.date import to_datetime
 
 
@@ -62,7 +62,7 @@ class Model(BaseModel):
     def __init__(self, *args, **kwargs):
         """Create a base model object."""
         logging.debug("args: %s, kwargs: %s", args, kwargs)
-        now = datetime.utcnow()  # .isoformat()
+        now = datetime.now(timezone.utc)  # .isoformat()
 
         self.id = kwargs.get("_id") or kwargs.get("id")
         logging.debug("id: %s", self.id)


### PR DESCRIPTION
base.py's Model.__init__ used datetime.utcnow(), deprecated in favor of timezone-aware datetimes. Surfaced as a hard test failure in sweetrpg-client, which runs under filterwarnings = ["error"] and constructs model objects via this path.

Verified locally under Python 3.14.6: all 18 tests pass.