### PR TITLE
Seed CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+<!--next-version-placeholder-->


### PR DESCRIPTION
prepare-release.yaml expects this file to already exist (git-cliff errors with an IO error otherwise) - this repo never had one, relying instead on relekang/python-semantic-release's own changelog mechanism (removed in #58).