### PR TITLE
Revert manual version bump to 0.0.156, matching the v0.0.156 tag

### DIFF
--- a/src/sweetrpg_model_core/__init__.py
+++ b/src/sweetrpg_model_core/__init__.py
@@ -7,7 +7,7 @@ Root.
 __title__ = "SweetRPG Model Core"
 __description__ = "Base classes and utilities for model objects"
 __url__ = "https://github.com/sweetrpg/model-core"
-__version__ = "0.0.157"
+__version__ = "0.0.156"
 __build__ = 0x000063
 __author_email__ = "dm@sweetrpg.com"
 __license__ = "MIT"


### PR DESCRIPTION
My earlier manual bump to 0.0.157 pre-empted what the now-working prepare-release automation computes itself, tripping its no-op guard. Reverting so the automation has real work to do.